### PR TITLE
Update RNG.scala

### DIFF
--- a/src/main/scala/chapter6/RNG.scala
+++ b/src/main/scala/chapter6/RNG.scala
@@ -33,7 +33,7 @@ object RNG {
    }
 
    def nextDouble(rng: RNG): (Double, RNG) = {
-      val (num, newState) = rng.nextInt
+      val (num, newState) = rng.nonNegativeInt
       (num / (Int.MaxValue.toDouble + 1), newState)
    }
 


### PR DESCRIPTION
double was supposed to return a number between 0 to 1 (not including 1)
We should take nonNegativeInt rather that nextInt